### PR TITLE
Use can_render to only show .atom when supported by the query

### DIFF
--- a/datasette_atom/__init__.py
+++ b/datasette_atom/__init__.py
@@ -9,7 +9,7 @@ REQUIRED_COLUMNS = {"atom_id", "atom_updated", "atom_title"}
 
 @hookimpl
 def register_output_renderer():
-    return {"extension": "atom", "callback": render_atom}
+    return {"extension": "atom", "render": render_atom, "can_render": can_render_atom}
 
 
 def render_atom(args, data, view_name):
@@ -64,6 +64,10 @@ def render_atom(args, data, view_name):
         "content_type": "application/xml; charset=utf-8",
         "status_code": 200,
     }
+
+
+def can_render_atom(columns):
+    return {"atom_id", "atom_title", "atom_updated"}.issubset(columns)
 
 
 def clean(html):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import os
 
-VERSION = "0.5"
+VERSION = "0.6"
 
 
 def get_long_description():
@@ -23,7 +23,7 @@ setup(
     version=VERSION,
     packages=["datasette_atom"],
     entry_points={"datasette": ["atom = datasette_atom"]},
-    install_requires=["datasette", "feedgen", "bleach"],
+    install_requires=["datasette~=0.43", "feedgen", "bleach"],
     extras_require={"test": ["pytest", "pytest-asyncio", "httpx"]},
     tests_require=["datasette-atom[test]"],
 )

--- a/tests/test_atom.py
+++ b/tests/test_atom.py
@@ -203,7 +203,8 @@ async def test_atom_link_only_shown_for_correct_queries():
     # But with a different query that link is not shown:
     async with httpx.AsyncClient(app=app) as client:
         response = await client.get(
-            "http://localhost/:memory:?" + urllib.parse.urlencode({"sql": "select sqlite_version()"})
+            "http://localhost/:memory:?"
+            + urllib.parse.urlencode({"sql": "select sqlite_version()"})
         )
     assert b'<a href="/:memory:.json' in response.content
     assert b'<a href="/:memory:.atom' not in response.content


### PR DESCRIPTION
Refs #10